### PR TITLE
Sample aura component updates with telephony actions @W-12476050@

### DIFF
--- a/ToolkitAPI/SampleAuraComponent/SampleComponent.cmp
+++ b/ToolkitAPI/SampleAuraComponent/SampleComponent.cmp
@@ -9,7 +9,17 @@
     <aura:attribute name="transcript" type="String" default="No transcripts received yet."/>
     <aura:attribute name="payload" type="String" default=""/>
     <aura:attribute name="phoneNumber" type="String" default=""/>
+    <aura:attribute name="addParticipantValue" type="String" default=""/>
+    <aura:attribute name="blindTransferValue" type="String" default=""/>
+    <aura:attribute name="digits" type="String" default=""/>
     <aura:attribute name="record" type="Object"/>
+    <aura:attribute name="options" type="List" default="[{'label': 'INITIAL_CALLER', 'value': 'Initial_Caller'}, {'label': 'THIRD_PARTY', 'value': 'Third_Party'}]" description="Participant type options" />
+    <aura:attribute name="contactOptions" type="List" default="[{ label: 'PHONE NUMBER', value: 'PhoneNumber' },{ label: 'AGENT/QUEUE ID', value: 'AgentOrQueueId' }]" description="Participant type options" />
+    <aura:attribute name="comboBoxHoldValue" type="String" default="Initial_Caller"/>   
+    <aura:attribute name="comboBoxResumeValue" type="String" default="Initial_Caller"/>
+    <aura:attribute name="comboBoxRemoveParticipantValue" type="String" default="Initial_Caller"/>
+    <aura:attribute name="comboBoxAddParticipantValue" type="String" default="PhoneNumber"/>
+    <aura:attribute name="comboBoxBlindTransferValue" type="String" default="PhoneNumber"/>
     
     <!-- get record data -->
     <force:recordData recordId="{!v.recordId}" layoutType="FULL" targetFields="{!v.record}"/>
@@ -43,7 +53,7 @@
             <lightning:formattedText value="{!'Recipient Number: ' + v.record.ToPhoneNumber}" class="slds-show"/>
         </p>
         
-        <p class="slds-text-title_caps slds-p-horizontal_medium slds-p-top_medium slds-p-bottom_small">HEADSET ACTIONS</p>
+        <p class="slds-text-title_caps slds-p-horizontal_medium slds-p-top_medium slds-p-bottom_small">TELEPHONY ACTIONS</p>
 
         <div class="slds-p-horizontal_medium">
             <div class="slds-grid slds-p-bottom_medium">
@@ -52,8 +62,80 @@
             </div>
             
             <div class="slds-grid slds-p-bottom_medium">
+            <lightning:combobox
+            name="hold"
+            label="Hold Participant type"
+            value="{!v.comboBoxHoldValue}"
+            placeholder="Select Participant type"
+            options="{!v.options}"
+            onchange="{! c.handleComboboxHoldChange}" ></lightning:combobox>
+            <lightning:button variant="brand" label="Hold" onclick="{! c.onHold}"></lightning:button>
+            </div>
+
+            <div class="slds-grid slds-p-bottom_medium" >
+             <lightning:combobox
+                name="resume"
+                label="Resume Participant type"
+                value="{!v.comboBoxResumeValue}"
+                placeholder="Select Participant type"
+                options="{!v.options}"
+                onchange="{! c.handleComboboxResumeChange}" ></lightning:combobox>
+            <lightning:button variant="brand" label="Resume" onclick="{! c.onResume}"></lightning:button>
+            </div>
+            
+            <div class="slds-grid slds-p-bottom_medium">
+            <lightning:combobox
+            name="Add Participant"
+            label="Add Participant type"
+            value="{!v.comboBoxAddParticipantValue}"
+            placeholder="Select Participant type"
+            options="{!v.contactOptions}"
+            onchange="{! c.handleComboboxAddParticipantChange}" ></lightning:combobox>
+            <lightning:input label="Add participant" value="{!v.addParticipantValue}"></lightning:input>
+            <lightning:button variant="brand" label="Add Participant" onclick="{! c.onAddParticipant}"></lightning:button>
+            </div>
+            
+            <div class="slds-grid slds-p-bottom_medium">
+            <lightning:combobox
+            name="Blind Transfer"
+            label="Add Participant type"
+            value="{!v.comboBoxBlindTransferValue}"
+            placeholder="Select Participant type"
+            options="{!v.contactOptions}"
+            onchange="{! c.handleComboboxBlindTransferChange}" ></lightning:combobox>
+            <lightning:input label="Blind Transfer" value="{!v.blindTransferValue}"></lightning:input>
+            <lightning:button variant="brand" label="Blind Transfer" onclick="{! c.onBlindTransfer}"></lightning:button>
+            </div>
+           
+            <div class="slds-grid slds-p-bottom_medium">
+                <lightning:button variant="brand" label="Pause Recording" title="Pause Recording" onclick="{! c.onPauseRecording }"/>
+                <lightning:button variant="brand" label="Resume Recording" title="Resume Recording" onclick="{! c.onResumeRecording }"/>
+            </div>
+            
+            <div class="slds-grid slds-p-bottom_medium">
+                <lightning:button variant="brand" label="Merge Call" title="Merge Call" onclick="{! c.onMerge }"/>
+                <lightning:button variant="brand" label="Swap Call" title="Swap Call" onclick="{! c.onSwap }"/>
+            </div>
+            
+            <div class="slds-grid slds-p-bottom_medium">
+            <lightning:input label="Send Digits" class="slds-p-horizontal_medium flex-input" value="{!v.digits}"/>
+            <lightning:button variant="brand" label="Send Digits" onclick="{!c.onSendDigits}"/>
+       		</div>
+            
+            <div class="slds-grid slds-p-bottom_medium">
                 <lightning:button variant="brand" label="Accept Call" title="Accept Call" onclick="{! c.onAcceptCall }"/>
                 <lightning:button variant="brand" label="Decline Call" title="Decline Call" onclick="{! c.onDeclineCall }"/>
+            </div>
+            
+            <div class="slds-grid slds-p-bottom_medium" >
+             <lightning:combobox
+                name="removeParticipant"
+                label="Remove Participant type"
+                value="{!v.comboBoxRemoveParticipantValue}"
+                placeholder="Select Participant type"
+                options="{!v.options}"
+                onchange="{! c.handleComboboxRemoveParticipantChange}" ></lightning:combobox>
+            <lightning:button variant="brand" label="Remove Participant" onclick="{! c.onRemoveParticipant}"></lightning:button>
             </div>
             
             <div class="slds-grid slds-p-bottom_medium">

--- a/ToolkitAPI/SampleAuraComponent/SampleComponent.cmp
+++ b/ToolkitAPI/SampleAuraComponent/SampleComponent.cmp
@@ -14,6 +14,7 @@
     <aura:attribute name="digits" type="String" default=""/>
     <aura:attribute name="record" type="Object"/>
     <aura:attribute name="options" type="List" default="[{'label': 'INITIAL_CALLER', 'value': 'Initial_Caller'}, {'label': 'THIRD_PARTY', 'value': 'Third_Party'}]" description="Participant type options" />
+    <aura:attribute name="endCallOptions" type="List" default="[{'label': 'INITIAL_CALLER', 'value': 'Initial_Caller'}, {'label': 'THIRD_PARTY', 'value': 'Third_Party'}, {'label': 'AGENT', 'value': 'Agent'}]" description="Participant type options" />
     <aura:attribute name="contactOptions" type="List" default="[{ label: 'PHONE NUMBER', value: 'PhoneNumber' },{ label: 'AGENT/QUEUE ID', value: 'AgentOrQueueId' }]" description="Participant type options" />
     <aura:attribute name="comboBoxHoldValue" type="String" default="Initial_Caller"/>   
     <aura:attribute name="comboBoxResumeValue" type="String" default="Initial_Caller"/>
@@ -127,18 +128,14 @@
                 <lightning:button variant="brand" label="Decline Call" title="Decline Call" onclick="{! c.onDeclineCall }"/>
             </div>
             
-            <div class="slds-grid slds-p-bottom_medium" >
-             <lightning:combobox
+            <div class="slds-grid slds-p-bottom_medium">
+                <lightning:combobox
                 name="removeParticipant"
                 label="Remove Participant type"
                 value="{!v.comboBoxRemoveParticipantValue}"
                 placeholder="Select Participant type"
-                options="{!v.options}"
+                options="{!v.endCallOptions}"
                 onchange="{! c.handleComboboxRemoveParticipantChange}" ></lightning:combobox>
-            <lightning:button variant="brand" label="Remove Participant" onclick="{! c.onRemoveParticipant}"></lightning:button>
-            </div>
-            
-            <div class="slds-grid slds-p-bottom_medium">
                 <lightning:button variant="brand" label="End Call" title="End Call" onclick="{! c.onEndCall }"/>
             </div>
         </div>

--- a/ToolkitAPI/SampleAuraComponent/SampleComponentController.js
+++ b/ToolkitAPI/SampleAuraComponent/SampleComponentController.js
@@ -35,10 +35,6 @@
         helper.declineCall(cmp);
     },
     
-    onRemoveParticipant: function(cmp, event, helper) {
-        helper.removeParticipant(cmp);
-    },
-    
     onEndCall: function(cmp, event, helper) {
         helper.endCall(cmp);
     },

--- a/ToolkitAPI/SampleAuraComponent/SampleComponentController.js
+++ b/ToolkitAPI/SampleAuraComponent/SampleComponentController.js
@@ -19,6 +19,14 @@
         helper.unmute(cmp);
     },
     
+    onMerge: function(cmp, event, helper) {
+        helper.merge(cmp);
+    },
+    
+    onSwap: function(cmp, event, helper) {
+        helper.swap(cmp);
+    },
+    
     onAcceptCall: function(cmp, event, helper) {
         helper.acceptCall(cmp);
     },
@@ -27,11 +35,63 @@
         helper.declineCall(cmp);
     },
     
+    onRemoveParticipant: function(cmp, event, helper) {
+        helper.removeParticipant(cmp);
+    },
+    
     onEndCall: function(cmp, event, helper) {
         helper.endCall(cmp);
     },
-
+    
     onStartPreviewCall: function(cmp, event, helper) {
         helper.startPreviewCall(cmp);
+    },
+    
+    onSendDigits: function(cmp, event, helper) {
+        helper.sendDigits(cmp);
+    },
+
+    onHold: function(cmp, event, helper) {
+        helper.hold(cmp);
+    },
+    
+    onResume: function(cmp, event, helper) {
+        helper.resume(cmp);
+    },
+    
+    onPauseRecording: function(cmp, event, helper) {
+        helper.pauseRecording(cmp);
+    },
+    
+    onResumeRecording: function(cmp, event, helper) {
+        helper.resumeRecording(cmp);
+    },
+    
+    onAddParticipant: function(cmp, event, helper) {
+        helper.addParticipant(cmp);
+    },
+    
+    onBlindTransfer: function(cmp, event, helper) {
+        helper.blindTransfer(cmp);
+    },
+    
+    handleComboboxHoldChange : function(cmp, event) {
+        cmp.set('v.comboBoxHoldValue', event.getParam("value"));
+    },
+    
+    handleComboboxResumeChange : function(cmp, event) {
+        cmp.set('v.comboBoxResumeValue', event.getParam("value"));
+    },
+    
+    handleComboboxRemoveParticipantChange : function(cmp, event) {
+        cmp.set('v.comboBoxRemoveParticipantValue', event.getParam("value"));
+    },
+    
+    handleComboboxAddParticipantChange : function(cmp, event) {
+        cmp.set('v.comboBoxAddParticipantValue', event.getParam("value"));
+    },
+    
+    handleComboboxBlindTransferChange : function(cmp, event) {
+        cmp.set('v.comboBoxBlindTransferValue', event.getParam("value"));
     }
 })

--- a/ToolkitAPI/SampleAuraComponent/SampleComponentHelper.js
+++ b/ToolkitAPI/SampleAuraComponent/SampleComponentHelper.js
@@ -52,13 +52,44 @@
         cmp.find('voiceToolkitApi').unmute()
     },
     
+    merge: function(cmp) {
+        cmp.find('voiceToolkitApi').merge()
+    },
+    
+    swap: function(cmp) {
+        cmp.find('voiceToolkitApi').swap()
+    },
+    
+    pauseRecording: function(cmp) {
+        cmp.find('voiceToolkitApi').pauseRecording()
+    },
+    
+    resumeRecording: function(cmp) {
+        cmp.find('voiceToolkitApi').resumeRecording()
+    },
+    
+    hold: function(cmp) {
+        var params = cmp.get('v.comboBoxHoldValue');
+        cmp.find('voiceToolkitApi').hold(params)
+    },
+    
+    resume: function(cmp) {
+        var params = cmp.get('v.comboBoxResumeValue');
+        cmp.find('voiceToolkitApi').resume(params)
+    },
+    
     acceptCall: function(cmp) {
         cmp.find('voiceToolkitApi').acceptCall()
     },
 
     declineCall: function(cmp) {
         cmp.find('voiceToolkitApi').declineCall()
-    },   
+    },
+    
+    removeParticipant: function(cmp) {
+        var params = cmp.get('v.comboBoxRemoveParticipantValue');
+        cmp.find('voiceToolkitApi').removeParticipant(params)
+    },
 
     endCall: function(cmp) {
         cmp.find('voiceToolkitApi').endCall()
@@ -67,5 +98,22 @@
     startPreviewCall: function(cmp) {
         var params = cmp.get('v.phoneNumber');
         cmp.find('voiceToolkitApi').startPreviewCall(params);
+    },
+    
+    sendDigits: function(cmp) {
+        var params = cmp.get('v.digits');
+        cmp.find('voiceToolkitApi').sendDigits(params);
+    },
+    
+    addParticipant: function(cmp) {
+        var param1 = cmp.get('v.comboBoxAddParticipantValue');
+        var param2 = cmp.get('v.addParticipantValue');
+        cmp.find('voiceToolkitApi').addParticipant(param1, param2, false);
+    },
+    
+    blindTransfer: function(cmp) {
+        var param1 = cmp.get('v.comboBoxBlindTransferValue');
+        var param2 = cmp.get('v.blindTransferValue');
+        cmp.find('voiceToolkitApi').addParticipant(param1, param2, true);
     }
 })

--- a/ToolkitAPI/SampleAuraComponent/SampleComponentHelper.js
+++ b/ToolkitAPI/SampleAuraComponent/SampleComponentHelper.js
@@ -85,14 +85,10 @@
     declineCall: function(cmp) {
         cmp.find('voiceToolkitApi').declineCall()
     },
-    
-    removeParticipant: function(cmp) {
-        var params = cmp.get('v.comboBoxRemoveParticipantValue');
-        cmp.find('voiceToolkitApi').removeParticipant(params)
-    },
 
     endCall: function(cmp) {
-        cmp.find('voiceToolkitApi').endCall()
+        var params = cmp.get('v.comboBoxRemoveParticipantValue');
+        cmp.find('voiceToolkitApi').endCall(params)
     },
 
     startPreviewCall: function(cmp) {


### PR DESCRIPTION
There are six more new telephony actions added to aura component toolkit api. These are Merge, Swap, Add Participant, Blind Transfer, Send Digits, Remove Participant. Previously available telephony actions were Hold, Resume, Pause and Resume recording which didn't have updates to SampleComponent, hence updating that as well.

Gus link: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001KUkBdYAL/view