### PR TITLE
@W-12359974@ Show telephony actions on callconnected

### DIFF
--- a/ToolkitAPI/sampleLWCComponent/sampleLWCComponent.js
+++ b/ToolkitAPI/sampleLWCComponent/sampleLWCComponent.js
@@ -86,7 +86,7 @@ export default class SampleLWCComponent extends LightningElement {
     }
 
     onTelephonyEvent(event) {
-        if (event.type === 'callstarted') {
+        if (event.type === 'callstarted' || event.type === 'callconnected') {
             this.telephonyActionControlsDisabled = false;
         }
         if (event.type === 'callended') {


### PR DESCRIPTION
When making voicecall outbound, it opens new tab and callconnected event should be used in order to show telephony actions.