### PR TITLE
Update SCVProvisioningPolicy.json

### DIFF
--- a/iam_policies/SCVProvisioningPolicy.json
+++ b/iam_policies/SCVProvisioningPolicy.json
@@ -220,7 +220,8 @@
                 "connect:UpdateRoutingProfileDefaultOutboundQueue",
                 "connect:PutUserStatus",
                 "connect:CreatePredefinedAttribute",
-                "connect:DeletePredefinedAttribute"
+                "connect:DeletePredefinedAttribute",
+                "connect:DeleteInstance"
             ],
             "Resource": [
                 "arn:aws:connect:*:<AWS_ACCOUNT_ID>:/instance",


### PR DESCRIPTION
You need this permission if you want to delete Amazon Connect instance from Salesforce. It is necessary from cloudformation